### PR TITLE
PHP 7.2 compatibility fix

### DIFF
--- a/framework/data/ArrayDataProvider.php
+++ b/framework/data/ArrayDataProvider.php
@@ -123,7 +123,7 @@ class ArrayDataProvider extends BaseDataProvider
      */
     protected function prepareTotalCount()
     {
-        return count($this->allModels);
+        return (is_array($this->allModels)) ? count($this->allModels) : 0;
     }
 
     /**


### PR DESCRIPTION
Fixes PHP 7.2 count(): Parameter must be an array or an object that implements Countable

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | 800
